### PR TITLE
fix: preserve unexpanded paths in config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,31 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
-    pub install_dir: PathBuf,
+    #[serde(rename = "install_dir")]
+    raw_install_dir: String,
+    #[serde(skip)]
+    expanded_install_dir: Option<PathBuf>,
+}
+
+impl Settings {
+    pub fn new(install_dir: &str) -> Self {
+        let expanded = expand_path(install_dir);
+        Self {
+            raw_install_dir: install_dir.to_string(),
+            expanded_install_dir: Some(PathBuf::from(expanded)),
+        }
+    }
+
+    pub fn install_dir(&self) -> PathBuf {
+        self.expanded_install_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(expand_path(&self.raw_install_dir)))
+    }
+
+    pub fn set_install_dir(&mut self, path: &str) {
+        self.raw_install_dir = path.to_string();
+        self.expanded_install_dir = Some(PathBuf::from(expand_path(path)));
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,9 +138,9 @@ impl Config {
         let mut config: Self = toml::from_str(&content)
             .map_err(|e| OktofetchError::ConfigError(e.to_string(), config_path))?;
 
-        // Expand environment variables and tilde in install_dir
-        let expanded_path = expand_path(&config.settings.install_dir.to_string_lossy());
-        config.settings.install_dir = PathBuf::from(expanded_path);
+        // Initialize the expanded path
+        config.settings.expanded_install_dir =
+            Some(PathBuf::from(expand_path(&config.settings.raw_install_dir)));
 
         Ok(config)
     }
@@ -183,11 +207,8 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        let install_dir = PathBuf::from(home).join(".local/bin");
-
         Self {
-            settings: Settings { install_dir },
+            settings: Settings::new("~/.local/bin"),
             tools: Vec::new(),
         }
     }
@@ -205,7 +226,7 @@ mod tests {
         assert!(
             config
                 .settings
-                .install_dir
+                .install_dir()
                 .to_string_lossy()
                 .contains(".local/bin")
         );
@@ -296,7 +317,7 @@ mod tests {
 
         // Create a config with a tool
         let mut config = Config::default();
-        config.settings.install_dir = PathBuf::from("/custom/path");
+        config.settings.set_install_dir("/custom/path");
         let tool = Tool {
             name: "k9s".to_string(),
             repo: "derailed/k9s".to_string(),
@@ -319,7 +340,7 @@ mod tests {
         assert_eq!(loaded_config.tools[0].repo, "derailed/k9s");
         assert_eq!(loaded_config.tools[0].version, Some("v0.32.5".to_string()));
         assert_eq!(
-            loaded_config.settings.install_dir,
+            loaded_config.settings.install_dir(),
             PathBuf::from("/custom/path")
         );
     }
@@ -551,7 +572,7 @@ mod tests {
         assert!(
             config
                 .settings
-                .install_dir
+                .install_dir()
                 .to_string_lossy()
                 .ends_with(".local/bin")
         );
@@ -584,16 +605,14 @@ mod tests {
 
     #[test]
     fn test_settings_serialization() {
-        let settings = Settings {
-            install_dir: PathBuf::from("/custom/path"),
-        };
+        let settings = Settings::new("/custom/path");
 
         let serialized = toml::to_string(&settings).unwrap();
         assert!(serialized.contains("install_dir"));
         assert!(serialized.contains("/custom/path"));
 
         let deserialized: Settings = toml::from_str(&serialized).unwrap();
-        assert_eq!(deserialized.install_dir, PathBuf::from("/custom/path"));
+        assert_eq!(deserialized.install_dir(), PathBuf::from("/custom/path"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
 use std::process;
 
 mod archive;
@@ -176,7 +175,7 @@ fn show_config(config: &Config) -> Result<()> {
     println!("Configuration:");
     println!(
         "  Install directory: {}",
-        config.settings.install_dir.display()
+        config.settings.install_dir().display()
     );
     println!("  Config file: {}", Config::config_path()?.display());
     Ok(())
@@ -185,7 +184,7 @@ fn show_config(config: &Config) -> Result<()> {
 fn set_config(config: &mut Config, key: &str, value: &str) -> Result<()> {
     match key {
         "install_dir" => {
-            config.settings.install_dir = PathBuf::from(value);
+            config.settings.set_install_dir(value);
             config.save()?;
             println!("Set install_dir to {}", value);
             Ok(())
@@ -200,6 +199,7 @@ fn set_config(config: &mut Config, key: &str, value: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_show_tool_info_not_found() {
@@ -242,14 +242,10 @@ mod tests {
     #[test]
     fn test_set_config_logic() {
         let mut config = Config::default();
-        let original_dir = config.settings.install_dir.clone();
 
         // Just test the logic without saving
-        config.settings.install_dir = PathBuf::from("/custom/path");
-        assert_eq!(config.settings.install_dir, PathBuf::from("/custom/path"));
-
-        // Restore
-        config.settings.install_dir = original_dir;
+        config.settings.set_install_dir("/custom/path");
+        assert_eq!(config.settings.install_dir(), PathBuf::from("/custom/path"));
     }
 
     #[test]
@@ -290,8 +286,8 @@ mod tests {
         let new_path = "/tmp/test_install";
 
         // Test the set_config function logic
-        config.settings.install_dir = PathBuf::from(new_path);
-        assert_eq!(config.settings.install_dir, PathBuf::from(new_path));
+        config.settings.set_install_dir(new_path);
+        assert_eq!(config.settings.install_dir(), PathBuf::from(new_path));
     }
 
     #[test]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -81,7 +81,7 @@ pub async fn update_tool(
 
     // Check if binary exists on disk
     let binary_name = tool.binary_name.as_deref().unwrap_or(&tool.name);
-    let binary_path = config.settings.install_dir.join(binary_name);
+    let binary_path = config.settings.install_dir().join(binary_name);
     let binary_exists = binary_path.exists();
 
     if !binary_exists {
@@ -164,7 +164,7 @@ pub async fn update_tool(
     }
 
     // Install binary
-    let dest = binary::install_binary(&binary_path, &config.settings.install_dir, binary_name)?;
+    let dest = binary::install_binary(&binary_path, &config.settings.install_dir(), binary_name)?;
 
     // Update version in config
     config.update_tool_version(&tool.name, release.tag_name.clone())?;
@@ -200,7 +200,7 @@ pub fn remove_tool(config: &mut Config, tool_name: &str) -> Result<()> {
     println!("Removed tool '{}'", tool_name);
     println!(
         "Note: Binary in {} not removed",
-        config.settings.install_dir.display()
+        config.settings.install_dir().display()
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Fixes config saving expanded paths instead of preserving original syntax

## Problem
When config is saved, `~/.local/bin` becomes `/home/user/.local/bin`, hardcoding the home directory.

## Solution
Refactored `Settings` to:
- Store raw path string (`raw_install_dir`) for serialization
- Provide `install_dir()` method for expanded path at runtime
- Provide `set_install_dir()` method for updates

## Changes
- `src/config.rs`: Refactored Settings struct with raw/expanded path separation
- `src/main.rs`: Updated to use new methods, removed unused import
- `src/tool.rs`: Updated to use `install_dir()` method

## Test plan
- [x] All 110 tests pass
- [x] Clippy passes with no warnings
- [x] Verified config preserves `~/.local/bin` after save operations

Closes #6