### PR TITLE
refactor: update dependencies and modernize codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,12 +138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,12 +172,11 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
@@ -276,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -304,6 +306,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -349,12 +366,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -612,9 +646,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1022,6 +1058,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,7 +1166,7 @@ dependencies = [
  "tar",
  "temp-env",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-test",
  "toml",
@@ -1203,26 +1260,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -1295,12 +1339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,7 +1364,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1587,17 +1625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,7 +1777,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1758,6 +1794,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2485,6 +2532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,6 +2589,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2569,21 +2639,31 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
- "byteorder",
+ "arbitrary",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
  "flate2",
+ "getrandom 0.3.4",
  "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
  "pbkdf2",
  "sha1",
+ "thiserror 2.0.17",
  "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
  "zstd",
 ]
 
@@ -2594,21 +2674,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ clap = { version = "4.5", features = ["derive", "env"] }
 
 # Error handling
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 
 # Async runtime
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.46", features = ["full"] }
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "stream"] }
@@ -31,16 +31,16 @@ toml = "0.8"
 
 # Archive handling
 tar = "0.4"
-flate2 = "1.0"
-bzip2 = "0.4"
-zip = "0.6"
+flate2 = "1.1"
+bzip2 = "0.5"
+zip = "2.2"
 
 # Progress indicators
 indicatif = "0.17"
 
 # Path utilities
 directories = "5.0"
-tempfile = "3.13"
+tempfile = "3.15"
 
 [dev-dependencies]
 temp-env = "0.3"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ A CLI tool to manage GitHub release binaries for Linux x86_64. Automatically dow
 - **GitHub Token Support** - Works with both classic and fine-grained personal access tokens
 - **Path Expansion** - Supports `~` and environment variables in configuration
 
+## Requirements
+
+### Minimum Supported Rust Version (MSRV)
+
+Rust 1.85.0 or later is required (edition 2024).
+
+### Build Dependencies
+
+- OpenSSL development libraries (`libssl-dev` on Debian/Ubuntu, `openssl-devel` on Fedora/RHEL)
+- pkg-config
+
 ## Installation
 
 ### From crates.io
@@ -196,6 +207,10 @@ Currently supports **Linux x86_64** only. Asset matching looks for:
 | 9    | Binary not found in archive      |
 | 10   | IO error                         |
 | 11   | HTTP error                       |
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## License
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,5 +1,17 @@
+//! Archive extraction module for handling various compressed formats.
+//!
+//! Supports the following archive formats:
+//! - `.tar.gz` and `.tgz` (gzip-compressed tar)
+//! - `.tar.bz2` and `.tbz` (bzip2-compressed tar)
+//! - `.zip` archives
+//! - Standalone ELF binaries (detected via magic header)
+//!
+//! All extraction functions include path traversal protection to prevent
+//! directory escape attacks from malicious archives.
+
 use crate::error::{OktofetchError, Result};
 use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 
 pub fn extract_archive(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
@@ -20,14 +32,11 @@ pub fn extract_archive(archive_path: &Path, dest_dir: &Path) -> Result<Vec<Strin
     }
 }
 
-fn extract_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
-    use flate2::read::GzDecoder;
+/// Extract files from a tar archive with the given reader (decoder).
+fn extract_tar<R: Read>(reader: R, dest_dir: &Path) -> Result<Vec<String>> {
     use tar::Archive;
 
-    let file = File::open(archive_path)?;
-    let gz = GzDecoder::new(file);
-    let mut archive = Archive::new(gz);
-
+    let mut archive = Archive::new(reader);
     let mut extracted_files = Vec::new();
 
     for entry in archive.entries()? {
@@ -59,43 +68,20 @@ fn extract_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
     Ok(extracted_files)
 }
 
-fn extract_tar_bz2(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
-    use bzip2::read::BzDecoder;
-    use tar::Archive;
+fn extract_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
+    use flate2::read::GzDecoder;
 
     let file = File::open(archive_path)?;
-    let bz = BzDecoder::new(file);
-    let mut archive = Archive::new(bz);
+    let decoder = GzDecoder::new(file);
+    extract_tar(decoder, dest_dir)
+}
 
-    let mut extracted_files = Vec::new();
+fn extract_tar_bz2(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
+    use bzip2::read::BzDecoder;
 
-    for entry in archive.entries()? {
-        let mut entry = entry?;
-        let path = entry.path()?.to_path_buf();
-
-        // Security: prevent path traversal
-        if path
-            .components()
-            .any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            continue;
-        }
-
-        let dest_path = dest_dir.join(&path);
-
-        // Create parent directories if needed
-        if let Some(parent) = dest_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        entry.unpack(&dest_path)?;
-
-        if let Some(path_str) = path.to_str() {
-            extracted_files.push(path_str.to_string());
-        }
-    }
-
-    Ok(extracted_files)
+    let file = File::open(archive_path)?;
+    let decoder = BzDecoder::new(file);
+    extract_tar(decoder, dest_dir)
 }
 
 fn extract_zip(archive_path: &Path, dest_dir: &Path) -> Result<Vec<String>> {
@@ -254,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_extract_zip() {
-        use zip::write::{FileOptions, ZipWriter};
+        use zip::write::{SimpleFileOptions, ZipWriter};
 
         let temp_dir = TempDir::new().unwrap();
         let archive_path = temp_dir.path().join("test.zip");
@@ -262,7 +248,8 @@ mod tests {
         // Create a zip archive
         let file = fs::File::create(&archive_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        zip.start_file("test.txt", FileOptions::default()).unwrap();
+        zip.start_file("test.txt", SimpleFileOptions::default())
+            .unwrap();
         zip.write_all(b"zip content").unwrap();
         zip.finish().unwrap();
 
@@ -343,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_extract_zip_with_dirs() {
-        use zip::write::{FileOptions, ZipWriter};
+        use zip::write::{SimpleFileOptions, ZipWriter};
 
         let temp_dir = TempDir::new().unwrap();
         let archive_path = temp_dir.path().join("test_dirs.zip");
@@ -353,11 +340,11 @@ mod tests {
         let mut zip = ZipWriter::new(file);
 
         // Add a directory
-        zip.add_directory("testdir/", FileOptions::default())
+        zip.add_directory("testdir/", SimpleFileOptions::default())
             .unwrap();
 
         // Add a file in that directory
-        zip.start_file("testdir/file.txt", FileOptions::default())
+        zip.start_file("testdir/file.txt", SimpleFileOptions::default())
             .unwrap();
         zip.write_all(b"content").unwrap();
         zip.finish().unwrap();

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,3 +1,13 @@
+//! Binary detection and installation module.
+//!
+//! Provides functionality to:
+//! - Find executable binaries in extracted archive contents
+//! - Detect ELF binaries via magic header (`0x7F 'E' 'L' 'F'`)
+//! - Install binaries to the configured directory with proper permissions
+//!
+//! ELF detection is used as a fallback when archives don't preserve execute
+//! permissions, which is common with some archive creators.
+
 use crate::error::{OktofetchError, Result};
 use std::fs::{self, File};
 use std::io::Read;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,23 @@
+//! Configuration management for oktofetch.
+//!
+//! Configuration is stored in TOML format at `~/.config/oktofetch/config.toml`.
+//!
+//! # Config File Structure
+//!
+//! ```toml
+//! [settings]
+//! install_dir = "~/.local/bin"
+//!
+//! [[tools]]
+//! name = "k9s"
+//! repo = "derailed/k9s"
+//! version = "v0.32.5"
+//! ```
+//!
+//! Path expansion supports:
+//! - Tilde expansion: `~/bin` → `/home/user/bin`
+//! - Environment variables: `$HOME/.local/bin` or `${HOME}/.local/bin`
+
 use crate::error::{OktofetchError, Result};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,20 @@
+//! Error types and exit codes for oktofetch.
+//!
+//! # Exit Codes
+//!
+//! | Code | Description                      |
+//! |------|----------------------------------|
+//! | 0    | Success                          |
+//! | 1    | Tool not found / General error   |
+//! | 2    | GitHub API error                 |
+//! | 3    | No suitable release for platform |
+//! | 4    | Configuration error              |
+//! | 7    | Download failed                  |
+//! | 8    | Extraction failed                |
+//! | 9    | Binary not found in archive      |
+//! | 10   | IO error                         |
+//! | 11   | HTTP error                       |
+
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,3 +1,12 @@
+//! GitHub API client for fetching releases and downloading assets.
+//!
+//! Supports authentication via the `GITHUB_TOKEN` environment variable.
+//! Both classic tokens and fine-grained personal access tokens (`github_pat_*`)
+//! are supported, with automatic detection of the appropriate authorization header.
+//!
+//! Rate limiting: Without a token, the GitHub API allows 60 requests/hour.
+//! With a token, this increases to 5,000 requests/hour.
+
 use crate::error::{OktofetchError, Result};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -19,6 +28,12 @@ pub struct Asset {
 pub struct GithubClient {
     client: Client,
     token: Option<String>,
+}
+
+impl Default for GithubClient {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl GithubClient {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,3 +1,11 @@
+//! Platform detection and validation module.
+//!
+//! Currently supports Linux x86_64 only. Asset matching looks for release
+//! files containing "linux" AND one of: "x86_64", "amd64", or "x64".
+//!
+//! The matching is case-insensitive and uses substring matching to handle
+//! various naming conventions used by different projects.
+
 use crate::error::Result;
 
 pub fn validate_platform() -> Result<()> {
@@ -18,6 +26,7 @@ pub fn validate_platform() -> Result<()> {
 
 /// Checks if an asset name matches Linux x86_64 platform requirements.
 /// Looks for "linux" and one of: "x86_64", "amd64", or "x64".
+#[must_use]
 pub fn matches_asset_name(name: &str) -> bool {
     let name_lower = name.to_lowercase();
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,3 +1,15 @@
+//! Tool management operations (add, update, remove, list).
+//!
+//! # Update Workflow
+//!
+//! 1. Validate platform (Linux x86_64)
+//! 2. Fetch latest release from GitHub API
+//! 3. Select matching asset (prefers tar.gz > zip > standalone binary)
+//! 4. Download asset to temporary directory
+//! 5. Extract archive
+//! 6. Find and install binary
+//! 7. Update version in config
+
 use crate::archive;
 use crate::binary;
 use crate::config::{Config, Tool};


### PR DESCRIPTION
## Summary

- Update major dependencies (thiserror 2.0, tokio 1.46, zip 2.2, bzip2 0.5)
- Refactor duplicate tar extraction into generic `extract_tar<R>()` function
- Add module documentation to all source files
- Add MSRV and build requirements to README

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` - all 112 tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo doc` builds successfully